### PR TITLE
reflect that Stream.gen got renamed to Stream.continually

### DIFF
--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -338,7 +338,7 @@ The new collections are based on http://docs.oracle.com/javase/8/docs/api/java/l
 [source,java]
 ----
 // 1000 random numbers
-for (double random : Stream.gen(Math::random).take(1000)) {
+for (double random : Stream.continually(Math::random).take(1000)) {
     ...
 }
 ----


### PR DESCRIPTION
fix for https://github.com/vavr-io/vavr-docs/issues/37