### PR TITLE
Typo fix in Match(...) example, Tuple => $Tuple

### DIFF
--- a/src/docs/asciidoc/pattern_matching.adoc
+++ b/src/docs/asciidoc/pattern_matching.adoc
@@ -190,7 +190,7 @@ Match(_try).of(
 [source,java]
 ----
 Match(_try).of(  
-    Case($Success(Tuple2($("a"), $())), tuple2 -> ...),
+    Case($Success($Tuple2($("a"), $())), tuple2 -> ...),
     Case($Failure($(instanceOf(Error.class))), error -> ...)
 );
 ----


### PR DESCRIPTION
docs.vavr.io provides an example for `Match` predicates:
```
Match(_try).of(
    Case($Success(Tuple2($("a"), $())), tuple2 -> ...),
    Case($Failure($(instanceOf(Error.class))), error -> ...)
);
```
(https://docs.vavr.io/#_patterns)

However, instead of `Tuple` type, the pattern `$Tuple` shall be used:
```
Match(_try).of(
    Case($Success($Tuple2($("a"), $())), tuple2 -> ...),
    Case($Failure($(instanceOf(Error.class))), error -> ...)
);
```

This PR addresses this typo.