### PR TITLE
Removing reference to javaslang 2.0.0 version

### DIFF
--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -266,7 +266,7 @@ Lazy is a monadic container type which represents a lazy evaluated value. Compar
 include::../../test/java/io/vavr/LazyDemo.java[tags=createLazy]
 ----
 
-Since version 2.0.0 you may also create a real lazy value (works only with interfaces):
+You may also create a real lazy value (works only with interfaces):
 
 [source,java,indent=0]
 ----


### PR DESCRIPTION
To address https://github.com/vavr-io/vavr-docs/issues/47

Here https://docs.vavr.io/#_lazy the documentation says:
```
Since version 2.0.0 you may also create a real lazy value (works only with interfaces):
```
To my understanding, this actually refers to `javaslang` v2.0.0, which may be confusing to vavr users. As far as I understand, any published `vavr` version implements this feature, so this PR proposes to remove the `Since version 2.0.0` clause.